### PR TITLE
Remove bourbon and fix icon deprecations

### DIFF
--- a/addon/pods/components/frost-notification/component.js
+++ b/addon/pods/components/frost-notification/component.js
@@ -22,11 +22,11 @@ export default Ember.Component.extend({
   notificationIcon: function (type) {
     switch (type) {
       case 'warning':
-        return 'notifications/warning'
+        return 'warning'
       case 'error':
-        return 'notifications/error'
+        return 'dialog-error'
       case 'info':
-        return 'notifications/info'
+        return 'info'
     }
   },
 

--- a/addon/pods/components/frost-notification/template.hbs
+++ b/addon/pods/components/frost-notification/template.hbs
@@ -16,6 +16,6 @@
 
   <span class="close" {{action "removeNotification"}}
         title="Dismiss this notification">
-    {{frost-icon icon='frost/close'}}
+    {{frost-icon icon='close'}}
   </span>
 </div>

--- a/addon/styles/_keyframes.scss
+++ b/addon/styles/_keyframes.scss
@@ -9,12 +9,12 @@
 @keyframes frost-notifications-show {
   0% {
     opacity: 0;
-    @include transform(perspective(450px) translate(0, -30px) rotateX(90deg));
+    transform: perspective(450px) translate(0, -30px) rotateX(90deg);
   }
 
   100% {
     opacity: 1;
-    @include transform(perspective(450px) translate(0, 0) rotateX(0deg));
+    transform: perspective(450px) translate(0, 0) rotateX(0deg);
   }
 }
 
@@ -27,14 +27,14 @@
     opacity: 0;
     max-height: $notification-max-height;
     margin-bottom: $notification-spacing;
-    @include transform(scale(.8));
+    transform: scale(.8);
   }
 
   100% {
     opacity: 0;
     max-height: 0;
     margin-bottom: 0;
-    @include transform(scale(.8));
+    transform: scale(.8);
   }
 }
 
@@ -45,12 +45,12 @@
 @keyframes frost-notifications-hide {
   0% {
     opacity: 1;
-    @include transform(scale(1));
+    transform: scale(1);
   }
 
   100% {
     opacity: 0;
-    @include transform(scale(.8));
+    transform: scale(.8);
   }
 }
 

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,3 +1,2 @@
-@import 'bower_components/bourbon/app/assets/stylesheets/bourbon';
 @import 'node_modules/ember-frost-core/addon/styles/frost-theme';
 @import 'frost-notifications';

--- a/addon/styles/frost-notifications.scss
+++ b/addon/styles/frost-notifications.scss
@@ -32,8 +32,8 @@
   max-height: $notification-max-height;
   color: $frost-color-white;
   box-shadow: 0px 3px 3px 0px rgba(0,0,0,0.25);
-  @include animation(frost-notifications-hide 250ms cubic-bezier(.33859, -.42, 1, -.22), frost-notifications-shrink 250ms 250ms cubic-bezier(.5, 0, 0, 1));
-  @include animation-fill-mode(forwards);
+  animation: frost-notifications-hide 250ms cubic-bezier(.33859, -.42, 1, -.22), frost-notifications-shrink 250ms 250ms cubic-bezier(.5, 0, 0, 1);
+  animation-fill-mode: forwards;
 }
 
 
@@ -41,7 +41,7 @@
 // -------------------------
 
 .frost-notifications-in {
-  @include animation(frost-notifications-show 180ms cubic-bezier(.175, .885, .32, 1.27499));
+  animation: frost-notifications-show 180ms cubic-bezier(.175, .885, .32, 1.27499);
 }
 
 

--- a/blueprints/ember-frost-notifier/index.js
+++ b/blueprints/ember-frost-notifier/index.js
@@ -11,7 +11,7 @@ module.exports = {
   afterInstall: function () {
     return this.addAddonsToProject({
       packages: [
-        {name: 'ember-frost-core', target: '>=0.0.14 <2.0.0'}
+        {name: 'ember-frost-core', target: '>=0.11.10 <2.0.0'}
       ]
     })
   }

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "ember-frost-notifier",
   "dependencies": {
-    "bourbon": "^4.2.6",
     "ember": "^2.3.1",
     "ember-cli-shims": "^0.1.0",
     "ember-cli-test-loader": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
+    "ember-browserify": "1.1.9",
     "ember-cli": "^2.3.0",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-blanket": "0.9.1",
+    "ember-cli-blanket": "0.9.4",
     "ember-cli-content-security-policy": "^0.5.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
@@ -42,15 +43,16 @@
     "ember-export-application-global": "^1.0.5",
     "ember-frost-core": ">=0.0.14 <2.0.0",
     "ember-load-initializers": "^0.5.1",
-    "ember-lodash": "^0.0.6",
+    "ember-lodash": "^0.0.7",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "^0.5.0",
     "ember-truth-helpers": "^1.2.0",
     "ember-try": "^0.2.0",
-    "eslint": "2.2.0",
-    "eslint-config-frost-standard": "^1.0.0",
+    "eslint": "^2.11.1",
+    "eslint-config-frost-standard": "^2.0.0",
     "liquid-fire": "^0.23.0",
-    "loader.js": "^4.0.1"
+    "loader.js": "^4.0.1",
+    "svg4everybody": "^2.0.3"
   },
   "keywords": [
     "ember-addon",

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,5 +1,5 @@
 import Ember from 'ember'
-import Resolver from 'ember/resolver'
+import Resolver from 'ember-resolver'
 import loadInitializers from 'ember-load-initializers'
 import config from './config/environment'
 

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,4 +1,4 @@
-import Resolver from 'ember/resolver'
+import Resolver from 'ember-resolver'
 import config from '../../config/environment'
 
 var resolver = Resolver.create()


### PR DESCRIPTION
#MINOR#

# CHANGELOG

* **Fixed** deprecation warnings around `frost-icon`.
* **Removed** usage of `bourbon`.