### PR TITLE
Deprecated `contains` to `includes`

### DIFF
--- a/addon/pods/components/frost-notification/component.js
+++ b/addon/pods/components/frost-notification/component.js
@@ -52,7 +52,7 @@ export default Component.extend({
    * @returns {String} class type
    */
   processedType: function (type) {
-    if (type && A(['info', 'success', 'warning', 'error']).contains(type)) {
+    if (type && A(['info', 'success', 'warning', 'error']).includes(type)) {
       return `frost-notifications-${type}`
     }
   },


### PR DESCRIPTION

### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

`contains` is now deprecated.
https://github.com/emberjs/ember.js/blob/v2.11.0/packages/ember-runtime/lib/mixins/array.js#L611

# CHANGELOG
- contains -> includes when processing types