### PR TITLE
updated usage of deprecated method describeComponent()

### DIFF
--- a/tests/integration/components/frost-notification-test.js
+++ b/tests/integration/components/frost-notification-test.js
@@ -2,9 +2,11 @@ import {expect} from 'chai'
 import Ember from 'ember'
 const {Service} = Ember
 import {$hook, initialize as initializeHook} from 'ember-hook'
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
+
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
 const notifierStub = Service.extend({
   removeNotification: function () {}
@@ -16,90 +18,86 @@ const notifierContentMessageHookName = `${notifierHookName}-content-message`
 const notifierContentDetailsHookName = `${notifierHookName}-content-details`
 const notifierCloseIconHookName = `${notifierHookName}-close-icon`
 
-describeComponent(
-  'frost-notification',
-  'Integration: FrostNotificationsComponent',
-  {
-    integration: true
-  },
-  function () {
-    let sandbox, notification
+const test = integration('frost-notification')
+describe(test.label, function () {
+  test.setup()
+
+  let sandbox, notification
+  beforeEach(function () {
+    initializeHook()
+    sandbox = sinon.sandbox.create()
+
+    this.register('service:notifier', notifierStub)
+    this.inject.service('notifier', {as: 'notifier'})
+
+    sandbox.stub(this.get('notifier'), 'removeNotification')
+
+    notification = {
+      message: 'test message',
+      details: 'details',
+      type: 'success',
+      autoClear: true,
+      clearDuration: 5000
+    }
+
+    this.set('notification', notification)
+  })
+
+  afterEach(function () {
+    sandbox.reset()
+  })
+
+  describe('renders', function () {
     beforeEach(function () {
-      initializeHook()
-      sandbox = sinon.sandbox.create()
-
-      this.register('service:notifier', notifierStub)
-      this.inject.service('notifier', {as: 'notifier'})
-
-      sandbox.stub(this.get('notifier'), 'removeNotification')
-
-      notification = {
-        message: 'test message',
-        details: 'details',
-        type: 'success',
-        autoClear: true,
-        clearDuration: 5000
-      }
-
-      this.set('notification', notification)
-    })
-
-    afterEach(function () {
-      sandbox.reset()
-    })
-
-    describe('renders', function () {
-      beforeEach(function () {
-        this.render(hbs`{{frost-notification notification=notification}}`)
-      })
-
-      it('the top-level container', function (done) {
-        expect($hook(notifierHookName)).to.have.length(1)
-        expect($hook(notifierContentHookName)).to.have.length(1)
-        expect($hook(notifierContentMessageHookName)).to.have.length(1)
-        expect($hook(notifierContentDetailsHookName)).to.have.length(1)
-
-        return capture('frost-notification', done, {
-          experimentalSvgs: true
-        })
-      })
-
-      it('the message', function () {
-        expect($hook(notifierContentMessageHookName).text()).to.match(/test message/)
-      })
-
-      it('the details link', function () {
-        expect($hook(notifierContentDetailsHookName)).to.have.length(1)
-      })
-    })
-
-    it('does not display details link when details aren\'t provided', function () {
-      this.set('notification.details', undefined)
-
       this.render(hbs`{{frost-notification notification=notification}}`)
-      expect($hook(notifierContentDetailsHookName)).not.to.have.length(1)
     })
 
-    it('calls onDetailsClick when the details link is clicked', function () {
-      let spy = sandbox.spy()
+    it('the top-level container', function (done) {
+      expect($hook(notifierHookName)).to.have.length(1)
+      expect($hook(notifierContentHookName)).to.have.length(1)
+      expect($hook(notifierContentMessageHookName)).to.have.length(1)
+      expect($hook(notifierContentDetailsHookName)).to.have.length(1)
 
-      this.set('notification.onDetailsClick', spy)
-      this.render(hbs`{{frost-notification notification=notification}}`)
-      $hook(notifierContentDetailsHookName).find('a').click()
-
-      expect(spy.calledWith('details')).to.equal(true)
+      return capture('frost-notification', done, {
+        experimentalSvgs: true
+      })
     })
 
-    it('removes the notification when closed', function () {
-      this.render(hbs`{{frost-notification notification=notification}}`)
-      $hook(notifierCloseIconHookName).click()
-
-      expect(this.get('notifier').removeNotification.called).to.equal(true)
+    it('the message', function () {
+      expect($hook(notifierContentMessageHookName).text()).to.match(/test message/)
     })
 
-    it('change hook', function () {
-      this.render(hbs`{{frost-notification notification=notification hook='my-hook'}}`)
-      expect($hook(`my-hook${notifierHookName}`)).to.have.length(1)
+    it('the details link', function () {
+      expect($hook(notifierContentDetailsHookName)).to.have.length(1)
     })
-  }
-)
+  })
+
+  it('does not display details link when details aren\'t provided', function () {
+    this.set('notification.details', undefined)
+
+    this.render(hbs`{{frost-notification notification=notification}}`)
+    expect($hook(notifierContentDetailsHookName)).not.to.have.length(1)
+  })
+
+  it('calls onDetailsClick when the details link is clicked', function () {
+    let spy = sandbox.spy()
+
+    this.set('notification.onDetailsClick', spy)
+    this.render(hbs`{{frost-notification notification=notification}}`)
+    $hook(notifierContentDetailsHookName).find('a').click()
+
+    expect(spy.calledWith('details')).to.equal(true)
+  })
+
+  it('removes the notification when closed', function () {
+    this.render(hbs`{{frost-notification notification=notification}}`)
+    $hook(notifierCloseIconHookName).click()
+
+    expect(this.get('notifier').removeNotification.called).to.equal(true)
+  })
+
+  it('change hook', function () {
+    this.render(hbs`{{frost-notification notification=notification hook='my-hook'}}`)
+    expect($hook(`my-hook${notifierHookName}`)).to.have.length(1)
+  })
+})

--- a/tests/integration/components/frost-notifier-test.js
+++ b/tests/integration/components/frost-notifier-test.js
@@ -1,8 +1,10 @@
 import {expect} from 'chai'
 import Ember from 'ember'
 const {A, Service} = Ember
-import {describeComponent, it} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {beforeEach, describe, it} from 'mocha'
+
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
 const notifierStub = Service.extend({
   notifications: A([
@@ -19,33 +21,29 @@ const notifierStub = Service.extend({
   ])
 })
 
-describeComponent(
-  'frost-notifier',
-  'Integration: FrostNotifierComponent',
-  {
-    integration: true
-  },
-  function () {
+const test = integration('frost-notifier')
+describe(test.label, function () {
+  test.setup()
+
+  beforeEach(function () {
+    this.register('service:notifier', notifierStub)
+    this.inject.service('notifier', {as: 'notifier'})
+  })
+
+  describe('renders', function () {
     beforeEach(function () {
-      this.register('service:notifier', notifierStub)
-      this.inject.service('notifier', {as: 'notifier'})
+      this.render(hbs`{{frost-notifier}}`)
     })
 
-    describe('renders', function () {
-      beforeEach(function () {
-        this.render(hbs`{{frost-notifier}}`)
-      })
-
-      it('the top-level container', function (done) {
-        expect(this.$()).to.have.length(1)
-        return capture('frost-notifier', done, {
-          experimentalSvgs: true
-        })
-      })
-
-      it('multiple notifications', function () {
-        expect(this.$('.frost-notifications')).to.have.length(2)
+    it('the top-level container', function (done) {
+      expect(this.$()).to.have.length(1)
+      return capture('frost-notifier', done, {
+        experimentalSvgs: true
       })
     })
-  }
-)
+
+    it('multiple notifications', function () {
+      expect(this.$('.frost-notifications')).to.have.length(2)
+    })
+  })
+})

--- a/tests/unit/notifier-service-test.js
+++ b/tests/unit/notifier-service-test.js
@@ -2,11 +2,12 @@ import {expect} from 'chai'
 import Ember from 'ember'
 const {run} = Ember
 import wait from 'ember-test-helpers/wait'
+import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
 import NotifierService from 'ember-frost-notifier/pods/services/notifier'
 
-describe('Notifier Service', function () {
+describe('Unit / Service / notifier', function () {
   let service, sandbox, notification
   beforeEach(function () {
     sandbox = sinon.sandbox.create()


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-notifier/issues/28

# CHANGELOG
* **Updated** integration tests to remove the deprecated use of `describeComponent()`