### PR TITLE
Improve linting

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,13 @@
+{
+  "plugins": {
+    "lint": {
+      "list-item-indent": false,
+      "maximum-line-length": false,
+      "no-duplicate-headings": false,
+      "no-multiple-toplevel-headings": false
+    }
+  },
+  "settings": {
+    "commonmark": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ deploy:
     branch: master
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
-    tags: false
+    tags: true
 after_deploy:
 - .travis/publish-gh-pages.sh
 notifications:

--- a/package.json
+++ b/package.json
@@ -8,13 +8,10 @@
     "test": "tests"
   },
   "scripts": {
-    "start": "ember server",
     "build": "ember build",
-    "test": "npm run lint && COVERAGE=true ember test",
-    "lint": "npm run eslint && npm run sass-lint && npm run md-lint",
-    "md-lint": "remark *.md",
-    "eslint": "eslint *.js addon app config tests --fix",
-    "sass-lint": "sass-lint -q -v"
+    "lint": "lint-all-the-things",
+    "start": "ember server",
+    "test": "npm run lint && COVERAGE=true ember test"
   },
   "repository": "https://github.com/ciena-frost/ember-frost-notifier.git",
   "engines": {
@@ -24,7 +21,8 @@
   "contributors": [
     "Roxanne Panthaky (https://github.com/rox163)",
     "Steven Glanzer (https://github.com/sglanzer)",
-    "David Fortin (https://github.com/dafortin)"
+    "David Fortin (https://github.com/dafortin)",
+    "Matthew Dahl (https://github.com/sandersky)"
   ],
   "license": "MIT",
   "devDependencies": {
@@ -54,14 +52,9 @@
     "ember-resolver": "^2.1.1",
     "ember-sinon": "0.6.0",
     "ember-spread": "^1.1.1",
-    "ember-test-utils": "^1.8.0",
+    "ember-test-utils": "^1.10.3",
     "ember-truth-helpers": "^1.3.0",
-    "eslint": "^3.14.0",
-    "eslint-config-frost-standard": "^5.3.2",
-    "loader.js": "^4.1.0",
-    "remark-cli": "^2.1.0",
-    "remark-lint": "^5.4.0",
-    "sass-lint": "^1.10.2"
+    "loader.js": "^4.1.0"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Updated** Travis to only publish when git tags are added in preparation for non-version bump pull requests.
* **Updated** linting to use linting tools from `ember-test-utils`.
