### PR TITLE
Used core info, warn, error icons instead of local

### DIFF
--- a/addon/pods/components/frost-notification/template.hbs
+++ b/addon/pods/components/frost-notification/template.hbs
@@ -5,7 +5,6 @@
         class="icon"
         hook=(concat hook '-notificationIcon')
         icon=notificationIcon
-        pack='frost-notifier'
       }}
     {{/unless}}
     <div class="message" data-test={{hook (concat hook '-notification-wrapper-content-message')}}>

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-frost-notifier",
   "dependencies": {
-    "ember": "^2.11.0",
+    "ember": "~2.11.0",
     "ember-cli-shims": "^0.1.0",
     "Faker": "^3.0.1",
     "pretender": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.5.0",
-    "ember-cli": "^2.11.0",
+    "ember-cli": "~2.11.0",
     "ember-cli-chai": "0.3.2",
     "ember-cli-code-coverage": "0.3.5",
     "ember-cli-dependency-checker": "^1.3.0",
@@ -46,7 +46,7 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-elsewhere": "0.4.1",
     "ember-export-application-global": "^1.1.1",
-    "ember-frost-core": "^1.7.5",
+    "ember-frost-core": "^1.11.0",
     "ember-hook": "^1.4.1",
     "ember-load-initializers": "0.6.3",
     "ember-prop-types": "^3.10.2",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Used** info, warning and error icons from `ember-frost-core`