### PR TITLE
Update travis CI to test with firefox latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
     packages:
     - google-chrome-stable
     - g++-4.8
-  firefox: 'latest-esr'
+  firefox: 'latest'
 
 cache:
   directories:


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [X] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Updated** travis CI to run against firefox latest