### PR TITLE
Update ember-cli 2.12.3 inter-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-cli-chai": "0.3.2",
     "ember-cli-code-coverage": "^0.3.10",
     "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-frost-blueprints": "^1.2.1",
     "ember-cli-htmlbars-inline-precompile": "0.3.12",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mocha": "0.13.2",
@@ -42,16 +43,16 @@
     "ember-computed-decorators": "0.3.0",
     "ember-concurrency": "0.7.19",
     "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-elsewhere": "0.4.1",
+    "ember-elsewhere": "1.0.1",
     "ember-export-application-global": "^1.0.5",
-    "ember-frost-core": "^1.23.2",
+    "ember-frost-core": "^1.23.10",
     "ember-hook": "^1.4.1",
     "ember-load-initializers": "^0.6.0",
-    "ember-prop-types": "^3.10.2",
+    "ember-prop-types": "^3.14.1",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.6.0",
     "ember-source": "~2.12.0",
-    "ember-spread": "^1.1.1",
+    "ember-spread": "^1.2.2",
     "ember-test-utils": "^5.1.1",
     "ember-truth-helpers": "^1.3.0",
     "loader.js": "^4.2.3",
@@ -64,7 +65,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-sass": "^5.1.0"
+    "ember-cli-sass": "5.6.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-cli-chai": "0.3.2",
     "ember-cli-code-coverage": "^0.3.10",
     "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-htmlbars-inline-precompile": "0.3.12",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mocha": "0.13.2",
     "ember-cli-shims": "^1.0.2",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Updated** ember-cli 2.12.3 inter-dependencies